### PR TITLE
Update travis, remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-dist: trusty
-sudo: required
+dist: bionic
 jdk:
   - openjdk11
 addons:


### PR DESCRIPTION
Sudo shouldn't be required as token permissions in sonarcloud fixed the issue with pushing to sonarcloud.

Updating the distro to the latest ubuntu image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/7)
<!-- Reviewable:end -->
