### PR TITLE
Configure linters to not fail gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,7 @@ detekt {
     config = files("config/detekt/detekt.yml")
     buildUponDefaultConfig = true
 }
+
+ktlint {
+    ignoreFailures = true
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 0
+  maxIssues: -1
   excludeCorrectable: false
   weights:
     # complexity: 2


### PR DESCRIPTION
Lint errors will now continue the build.

This should still create reports to send to SonarCloud to raise alerts on pull requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/8)
<!-- Reviewable:end -->
