### PR TITLE
Fix zip file output damaged

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/DirectoryProviderImpl.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/DirectoryProviderImpl.kt
@@ -17,7 +17,7 @@ class DirectoryProviderImpl : DirectoryProvider {
     }
 
     override fun getDownloadDir(): File {
-        return File(System.getenv("RC_TEMP")).apply { mkdirs() }
+        return File(System.getenv("RC_TEMP_DIR")).apply { mkdirs() }
     }
 
     override fun getRCRepositoriesDir(): File {

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
@@ -38,8 +38,9 @@ class RequestResourceContainer(
 
         val zipFile = rcFile.parentFile.resolve("${rcFile.name}.zip")
             .apply { createNewFile() }
+        val packedUp = RCUtils.zipDirectory(rcFile, zipFile)
 
-        return if (hasContent || RCUtils.zipDirectory(rcFile, zipFile)) {
+        return if (hasContent || packedUp) {
             RCDeliverable(deliverable, zipFile.path)
         } else {
             rcFile.deleteRecursively()


### PR DESCRIPTION
Leaving the call to zipDirectory( ) inside if ( ) statement resulted in a damaged zip file. Now moved to a separate line

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/75)
<!-- Reviewable:end -->
