### PR TITLE
Send all exceptions to sentry

### DIFF
--- a/fetcher-pipeline/book_worker.py
+++ b/fetcher-pipeline/book_worker.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import re
+import traceback
+
 from pydub import AudioSegment
 from pathlib import Path
 from typing import List, Dict
@@ -75,9 +77,9 @@ class BookWorker:
                 try:
                     self.create_book_file(key, book_groups[key])
                 except Exception as e:
-                    logging.warning(str(e))
+                    logging.error(f"Error: {e}", extra={"stacktrace": traceback.format_exc()})
         except Exception as e:
-            logging.warning(str(e))
+            logging.error(f"Error: {e}", extra={"stacktrace": traceback.format_exc()})
         finally:
             logging.debug(f'Deleting temporary directory {self.__temp_dir}')
             rm_tree(self.__temp_dir)

--- a/fetcher-pipeline/chapter_worker.py
+++ b/fetcher-pipeline/chapter_worker.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import traceback
 from pathlib import Path
 from typing import Dict
 
@@ -38,7 +39,11 @@ class ChapterWorker:
             try:
                 self.process_chapter(src_file)
             except Exception as e:
-                logging.warning(str(e))
+                error_data = {
+                    "file": str(src_file),
+                    "stacktrace": traceback.format_exc()
+                }
+                logging.error(f"Error: {e}", extra=error_data)
 
         logging.debug(f'Deleting temporary directory {self.__temp_dir}')
         rm_tree(self.__temp_dir)

--- a/fetcher-pipeline/process_tools.py
+++ b/fetcher-pipeline/process_tools.py
@@ -56,7 +56,7 @@ def run_process(command, verbose=False):
     if process.returncode != 0:
         error_data = {
             "command": command,
-            "error": process.stderr
+            "stacktrace": process.stderr
         }
 
         logging.error(f"Error: {command}", extra=error_data)

--- a/fetcher-pipeline/tr_worker.py
+++ b/fetcher-pipeline/tr_worker.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import traceback
 from enum import Enum
 from pathlib import Path
 from typing import List, Tuple, Dict
@@ -87,7 +88,7 @@ class TrWorker:
             self.create_chapter_trs()
             self.create_book_trs()
         except Exception as e:
-            logging.warning(str(e))
+            logging.error(f"Error: {e}", extra={"stacktrace": traceback.format_exc()})
         finally:
             logging.debug(f'Deleting temporary directory {self.__temp_dir}')
             rm_tree(self.__temp_dir)
@@ -154,7 +155,7 @@ class TrWorker:
             try:
                 self.create_tr_file(key, chapter_groups[key])
             except Exception as e:
-                logging.warning(str(e))
+                logging.error(f"Error: {e}", extra={"stacktrace": traceback.format_exc()})
 
     def create_book_trs(self):
         book_groups = self.group_files(self.__book_tr_files, Group.BOOK)
@@ -162,7 +163,7 @@ class TrWorker:
             try:
                 self.create_tr_file(key, book_groups[key])
             except Exception as e:
-                logging.warning(str(e))
+                logging.error(f"Error: {e}", extra={"stacktrace": traceback.format_exc()})
 
     def create_tr_file(self, dic: str, files: List[Path]):
         """ Create tr file and copy it to the remote directory"""

--- a/fetcher-pipeline/verse_worker.py
+++ b/fetcher-pipeline/verse_worker.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import traceback
 from pathlib import Path
 from typing import Dict
 
@@ -37,7 +38,11 @@ class VerseWorker:
             try:
                 self.process_verse(src_file)
             except Exception as e:
-                logging.warning(str(e))
+                error_data = {
+                    "file": str(src_file),
+                    "stacktrace": traceback.format_exc()
+                }
+                logging.error(f"Error: {e}", extra=error_data)
 
         logging.debug(f'Deleting temporary directory {self.__temp_dir}')
         rm_tree(self.__temp_dir)


### PR DESCRIPTION
Log Exceptions as Errors instead of Warnings, to send them to Sentry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/105)
<!-- Reviewable:end -->
