### PR TITLE
Optimize Orature file creation

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
@@ -1,12 +1,12 @@
 package org.bibletranslationtools.fetcher.impl.repository
 
 import io.ktor.http.HttpStatusCode
-import org.bibletranslationtools.fetcher.data.Book
-import org.bibletranslationtools.fetcher.data.Language
-import org.bibletranslationtools.fetcher.data.Product
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
+import org.bibletranslationtools.fetcher.data.Book
+import org.bibletranslationtools.fetcher.data.Language
+import org.bibletranslationtools.fetcher.data.Product
 import org.bibletranslationtools.fetcher.repository.BookRepository
 import org.bibletranslationtools.fetcher.repository.ChapterCatalog
 import org.bibletranslationtools.fetcher.repository.LanguageCatalog

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/RCUtils.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/RCUtils.kt
@@ -100,7 +100,7 @@ object RCUtils {
 
     private fun checkFromDirectory(rcFile: File, chapterPath: String): Boolean {
         return rcFile.walk().any {
-            it.invariantSeparatorsPath.matches(Regex("^$chapterPath\$"))
+            it.invariantSeparatorsPath.matches(Regex(".*$chapterPath\$"))
         }
     }
 }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
@@ -1,8 +1,8 @@
 package org.bibletranslationtools.fetcher.usecase
 
 import io.ktor.client.features.ClientRequestException
-import org.bibletranslationtools.fetcher.data.Book
 import java.io.File
+import org.bibletranslationtools.fetcher.data.Book
 import org.bibletranslationtools.fetcher.data.Chapter
 import org.bibletranslationtools.fetcher.data.Language
 import org.bibletranslationtools.fetcher.data.Product

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/web/controllers/ChapterController.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/web/controllers/ChapterController.kt
@@ -26,7 +26,6 @@ import org.bibletranslationtools.fetcher.web.controllers.utils.PRODUCT_PARAM_KEY
 import org.bibletranslationtools.fetcher.web.controllers.utils.UrlParameters
 import org.bibletranslationtools.fetcher.web.controllers.utils.contentLanguage
 import org.bibletranslationtools.fetcher.web.controllers.utils.errorPage
-import org.bibletranslationtools.fetcher.web.controllers.utils.getLanguageName
 import org.bibletranslationtools.fetcher.web.controllers.utils.getPreferredLocale
 import org.bibletranslationtools.fetcher.web.controllers.utils.validator
 

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/web/controllers/ProductController.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/web/controllers/ProductController.kt
@@ -15,7 +15,6 @@ import org.bibletranslationtools.fetcher.web.controllers.utils.LANGUAGE_PARAM_KE
 import org.bibletranslationtools.fetcher.web.controllers.utils.UrlParameters
 import org.bibletranslationtools.fetcher.web.controllers.utils.contentLanguage
 import org.bibletranslationtools.fetcher.web.controllers.utils.errorPage
-import org.bibletranslationtools.fetcher.web.controllers.utils.getLanguageName
 import org.bibletranslationtools.fetcher.web.controllers.utils.getPreferredLocale
 import org.bibletranslationtools.fetcher.web.controllers.utils.normalizeUrl
 import org.bibletranslationtools.fetcher.web.controllers.utils.validator

--- a/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/RCUtilTest.kt
+++ b/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/RCUtilTest.kt
@@ -12,7 +12,6 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.rcmediadownloader.data.MediaType
 
 class RCUtilTest {
-    private val rcFileName = "titus_test.zip"
     private val testCaseFileName = "VerifyChapterExists_TestCases.json"
     private val logger = LoggerFactory.getLogger(javaClass)
 
@@ -25,24 +24,30 @@ class RCUtilTest {
 
     @Test
     fun testVerifyChapterExists() {
-        val rcFile = getTestRCFile()
+        val rcFiles = listOf(
+            getTestRCFile("titus_test"),
+            getTestRCFile("titus_test.zip")
+        )
         val testCases = getVerifyChapterExistsTestCase()
-        for (case in testCases) {
-            val mediaTypes = case.mediaTypes.mapNotNull { MediaType.get(it) }
-            val result = RCUtils.verifyChapterExists(
-                rcFile,
-                case.bookSlug,
-                mediaTypes,
-                case.chapterNumber
-            )
-            assertEquals(case.expectedResult, result)
+
+        rcFiles.forEach { rcFile ->
+            for (case in testCases) {
+                val mediaTypes = case.mediaTypes.mapNotNull { MediaType.get(it) }
+                val result = RCUtils.verifyChapterExists(
+                    rcFile,
+                    case.bookSlug,
+                    mediaTypes,
+                    case.chapterNumber
+                )
+                assertEquals(case.expectedResult, result)
+            }
         }
     }
 
     @Throws(FileNotFoundException::class)
-    private fun getTestRCFile(): File {
-        val rcFilePath = javaClass.classLoader.getResource(rcFileName)
-            ?: throw(FileNotFoundException("Test resource not found: $rcFileName"))
+    private fun getTestRCFile(rcName: String): File {
+        val rcFilePath = javaClass.classLoader.getResource(rcName)
+            ?: throw(FileNotFoundException("Test resource not found: $rcName"))
         return File(rcFilePath.file)
     }
 

--- a/fetcher-web/src/test/resources/titus_test/.gitattributes
+++ b/fetcher-web/src/test/resources/titus_test/.gitattributes
@@ -1,0 +1,2 @@
+# Set line endings to Unix
+text eol=lf

--- a/fetcher-web/src/test/resources/titus_test/.github/CONTRIBUTING.md
+++ b/fetcher-web/src/test/resources/titus_test/.github/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing to the English Unlocked Literal Bible
+
+Thank you for your help!
+
+If you have a suggestion to be made, you have one of two options:
+
+1. Fork this repository, make the change and create a pull request. We'll review it and merge it in.
+1. [Submit an issue](https://git.door43.org/Door43/en_ulb/issues/new). Please be detailed in your report.
+

--- a/fetcher-web/src/test/resources/titus_test/.github/ISSUE_TEMPLATE.md
+++ b/fetcher-web/src/test/resources/titus_test/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+**Thank you so much for submitting a suggested change.**
+ 
+**If the  issue is about a particular verse  or passage, we ask that you title the issue starting with the 3 letter code of the book followed by the chapter number, colon, and verse number(s), and then give some indication of what the issue is about. For example:**
+ 
+PSA 10:7 "his tongue injures and destroys"
+
+PHP 1:9-11  Remove sentence breaks?
+ 
+**If the issue is about a particular word or expression that occurs throughout the Bible, please simply use a title appropriate to the issue. For example:**
+ 
+”Saints" or ”Believers”
+
+In footnotes, change ”omit” to ”does not have”
+ 
+**Then please explain the issue in this box, giving an example from the ULB as  it stands now and a suggestion for how to fix it.**
+
+**Formatting: If you want a line break, put two spaces after the line and hit the return key.**
+

--- a/fetcher-web/src/test/resources/titus_test/.gitignore
+++ b/fetcher-web/src/test/resources/titus_test/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/fetcher-web/src/test/resources/titus_test/60-JAS.usfm
+++ b/fetcher-web/src/test/resources/titus_test/60-JAS.usfm
@@ -1,0 +1,219 @@
+\id JAS Unlocked Literal Bible
+\ide UTF-8
+\h James
+\toc1 The Letter of James
+\toc2 James
+\toc3 Jas
+\mt James
+
+\s5
+\c 1
+\p
+\v 1 James, a servant of God and of the Lord Jesus Christ, to the twelve tribes in the dispersion: Greetings!
+\v 2 Consider it all joy, my brothers, when you experience various troubles.
+\v 3 You know that the testing of your faith produces endurance.
+
+\s5
+\v 4 Let endurance complete its work so that you may become fully developed and complete, not lacking anything.
+\v 5 But if any of you needs wisdom, let him ask for it from God, the one who gives generously and without rebuke to all who ask, and he will give it to him.
+
+\s5
+\v 6 But let him ask in faith, doubting nothing. For anyone who doubts is like a wave in the sea that is driven by the wind and tossed around.
+\v 7 For that person must not think that he will receive anything from the Lord;
+\v 8 he is a double-minded man, unstable in all his ways.
+
+\s5
+\v 9 Let the brother of low condition boast of his high position,
+\v 10 but the rich man of his low position, because he will pass away as a wild flower in the grass.
+\v 11 For the sun rises with burning heat and dries up the grass. The flower falls off, and its beauty perishes. In the same way, the rich man will fade away in the middle of his journey.
+
+\s5
+\v 12 Blessed is the man who endures testing. For after he has passed the test, he will receive the crown of life, which has been promised to those who love God.
+\v 13 Let no one say when he is tempted, "I am tempted by God," because God is not tempted by evil, nor does he himself tempt anyone.
+
+\s5
+\v 14 But each person is tempted by his own desire, which drags him away and entices him.
+\v 15 Then after the desire conceives, it gives birth to sin, and after the sin is full grown, it gives birth to death.
+\v 16 Do not be deceived, my beloved brothers.
+
+\s5
+\v 17 Every good gift and every perfect gift is from above. It comes down from the Father of lights. With him there is no changing or shadow because of turning.
+\v 18 God chose to give us birth by the word of truth, so that we would be a kind of firstfruits of all the things that he created.
+
+\s5
+\v 19 You know this, my beloved brothers: Let every man be quick to hear, slow to speak, and slow to anger.
+\v 20 For the anger of man does not accomplish the righteousness of God.
+\v 21 Therefore take off all sinful filth and abundant amounts of evil. In humility receive the implanted word, which is able to save your souls.
+
+\s5
+\v 22 Be doers of the word and not only hearers, deceiving yourselves.
+\v 23 For if anyone is a hearer of the word but not a doer, he is like a man who examines his natural face in a mirror.
+\v 24 He examines himself and then goes away and immediately forgets what he was like.
+\v 25 But the person who looks carefully into the perfect law of freedom, and continues to do so, not just being a hearer who forgets, this man will be blessed in his actions.
+
+\s5
+\v 26 If anyone thinks he is religious and does not control his tongue, he deceives his heart and his religion is worthless.
+\v 27 Religion that is pure and unspoiled before our God and Father is to help the fatherless and widows in their affliction, and to keep oneself unstained by the world.
+
+\s5
+\c 2
+\p
+\v 1 My brothers, do not hold to faith in our Lord Jesus Christ, the Lord of glory, with partiality toward certain people.
+\v 2 Suppose that someone enters your meeting wearing gold rings and fine clothes, and there also enters a poor man in dirty clothes.
+\v 3 If you look at the person wearing fine clothes and say, "You sit here in a good place," but you say to the poor man, "You stand over there" or "Sit by my footstool,"
+\v 4 are you not judging among yourselves? Have you not become judges with evil thoughts?
+
+\s5
+\v 5 Listen, my beloved brothers, did not God choose the poor of the world to be rich in faith and to be heirs of the kingdom that he promised to those who love him?
+\v 6 But you have dishonored the poor! Is it not the rich who oppress you? Are they not the ones who drag you to court?
+\v 7 Do they not insult the good name by which you have been called?
+
+\s5
+\v 8 If, however, you fulfill the royal law according to the scripture, "Love your neighbor as yourself," you do well.
+\v 9 But if you favor certain people, you are committing sin, and you are convicted by the law as transgressors.
+
+\s5
+\v 10 For whoever obeys the whole law, except that he stumbles in just a single way, has become guilty of breaking the whole law.
+\v 11 For the one who said, "Do not commit adultery," also said, "Do not murder." If you do not commit adultery, but if you do commit murder, you have become a transgressor of the law.
+
+\s5
+\v 12 So speak and act as those who will be judged by means of the law of freedom.
+\v 13 For judgment comes without mercy to those who have shown no mercy. Mercy triumphs over judgment.
+
+\s5
+\p
+\v 14 What profit is it, my brothers, if someone says he has faith, but he has no works? Can that faith save him?
+\v 15 Suppose that a brother or sister is badly clothed and lacks food for the day.
+\v 16 Suppose that one of you says to them, "Go in peace, stay warm and be filled." If you do not give them the things necessary for the body, what profit is that?
+\v 17 In the same way faith by itself, if it does not have works, is dead.
+
+\s5
+\v 18 Yet someone may say, "You have faith, and I have works." Show me your faith without works, and I will show you my faith by my works.
+\v 19 You believe that there is one God; you do well. But even the demons believe that, and they tremble.
+\v 20 Do you want to know, foolish man, that faith without works is useless? \f + \ft Some important and ancient Greek copies read, \fqa Do you want to know, foolish man, how it is that faith without works is dead? \fqa* \f*
+
+\s5
+\v 21 Was not Abraham our father justified by works when he offered up Isaac his son on the altar?
+\v 22 You see that faith worked with his works, and that by works his faith was completed.
+\v 23 The scripture was fulfilled that says, "Abraham believed God, and it was counted to him as righteousness," and he was called a friend of God.
+\v 24 You see that it is by works that a man is justified, and not only by faith.
+
+\s5
+\v 25 In the same way also, was not Rahab the prostitute justified by works when she welcomed the messengers and sent them away by another road?
+\v 26 For as the body apart from the spirit is dead, even so faith apart from works is dead.
+
+\s5
+\c 3
+\p
+\v 1 Not many of you should become teachers, my brothers, for you know that we who teach will be judged more strictly.
+\v 2 For we all stumble in many ways. If anyone does not stumble in words, he is a perfect man, able to control even his whole body.
+
+\s5
+\v 3 Now if we put bits into horses' mouths for them to obey us, we can also direct their whole bodies.
+\v 4 Notice also that ships, although they are so large and are driven by strong winds, are steered by a very small rudder to wherever the pilot desires.
+
+\s5
+\v 5 In this way, the tongue is a small member, yet it boasts great things. Notice also how small a fire sets on fire a large forest.
+\v 6 The tongue is also a fire, a world of evil set among our members. The tongue defiles the whole body, sets on fire the course of life, and is itself set on fire by hell.
+
+\s5
+\v 7 For every kind of wild animal, bird, reptile, and sea creature is being tamed and has been tamed by mankind.
+\v 8 But no human being can tame the tongue. It is a restless evil, full of deadly poison.
+
+\s5
+\v 9 With it we praise the Lord and Father, and with it we curse men, who have been made in God's likeness.
+\v 10 Out of the same mouth come blessing and cursing. My brothers, these things should not happen.
+
+\s5
+\v 11 Does a spring pour out from its opening both sweet and bitter water?
+\v 12 Does a fig tree, my brothers, make olives? Or a grapevine, figs? Neither can salty water produce sweet water.
+
+\s5
+\p
+\v 13 Who is wise and understanding among you? Let that person show a good life by his works in the humility of wisdom.
+\v 14 But if you have bitter jealousy and ambition in your heart, do not boast and lie against the truth.
+
+\s5
+\v 15 This is not the wisdom that comes down from above. Instead, it is earthly, unspiritual, demonic.
+\v 16 For where there are jealousy and ambition, there is confusion and every evil practice.
+\v 17 But the wisdom from above is first pure, then peace-loving, gentle, reasonable, full of mercy and good fruits, impartial and sincere.
+\v 18 The fruit of righteousness is sown in peace among those who make peace.
+
+\s5
+\c 4
+\p
+\v 1 Where do quarrels and disputes among you come from? Do they not come from your desires that fight among your members?
+\v 2 You desire, and you do not have. You kill and covet, and you are not able to obtain. You fight and quarrel. You do not possess because you do not ask.
+\v 3 You ask and do not receive because you ask wrongly, in order that you may use it for your desires.
+
+\s5
+\v 4 You adulteresses! Do you not know that friendship with the world is hostility against God? So whoever desires to be a friend of the world makes himself an enemy of God.
+\v 5 Or do you think the scripture says in vain, "The Spirit he caused to live in us is deeply jealous"?
+
+\s5
+\v 6 But God gives more grace, so the scripture says, "God opposes the proud, but gives grace to the humble."
+\p
+\v 7 So submit to God. Resist the devil, and he will flee from you.
+
+\s5
+\v 8 Come close to God, and he will come close to you. Cleanse your hands, you sinners, and purify your hearts, you double-minded people.
+\v 9 Grieve, mourn, and cry! Let your laughter turn into sadness and your joy into gloom.
+\v 10 Humble yourselves before the Lord, and he will exalt you.
+
+\s5
+\p
+\v 11 Do not speak against one another, brothers. The person who speaks against a brother or judges his brother speaks against the law and judges the law. If you judge the law, you are not a doer of the law, but a judge.
+\v 12 Only one is the lawgiver and judge. He is the one who is able to save and to destroy. Who are you, you who judge your neighbor?
+
+\s5
+\p
+\v 13 Now listen, you who say, "Today or tomorrow we will go into this city, spend a year there, trade, and make a profit."
+\v 14 Who knows what will happen tomorrow, and what is your life? For you are a mist that appears for a little while and then disappears.
+
+\s5
+\v 15 Instead, you should say, "If the Lord wishes, we will live and do this or that."
+\v 16 But now you are boasting about your arrogant plans. All such boasting is evil.
+\v 17 So for anyone who knows to do good but does not do it, for him it is sin.
+
+\s5
+\c 5
+\p
+\v 1 Come now, you who are rich, weep and wail because of the miseries coming on you.
+\v 2 Your riches have rotted, and your clothes have become moth-eaten.
+\v 3 Your gold and your silver have become tarnished and their rust will be a witness against you. It will consume your flesh like fire. You have stored up your treasure for the last days.
+
+\s5
+\v 4 Look, the wages you kept back from the laborers who mowed your fields is crying out against you. The cries of the harvesters have reached the ears of the Lord of hosts.
+\v 5 You have lived in luxury on the earth and indulged yourselves. You have fattened your hearts for a day of slaughter.
+\v 6 You have condemned and killed the righteous person. He does not resist you.
+
+\s5
+\p
+\v 7 Be patient, then, brothers, until the Lord's coming. See how the farmer waits for the precious fruit from the ground and he is patient about it, until it receives the early and late rains.
+\v 8 You, too, be patient. Strengthen your hearts because the Lord's coming is near.
+
+\s5
+\v 9 Do not complain, brothers, against one another, so that you will be not condemned. See, the judge is standing at the door.
+\v 10 Take an example, brothers, from the suffering and patience of the prophets, those who spoke in the name of the Lord.
+\v 11 See, we regard those who endured as blessed. You have heard of the endurance of Job, and you know the purpose of the Lord, how he is very compassionate and merciful.
+
+\s5
+\p
+\v 12 Above all, my brothers, do not swear, either by heaven or by the earth, or by any other oath. Instead, let your "Yes" mean "Yes" and your "No" mean "No," so you do not fall under judgment.
+
+\s5
+\p
+\v 13 Is anyone among you suffering hardship? Let him pray. Is anyone cheerful? Let him sing praise.
+\v 14 Is anyone among you sick? Let him call for the elders of the church, and let them pray over him. Let them anoint him with oil in the name of the Lord.
+\v 15 The prayer of faith will heal the sick person, and the Lord will raise him up. If he has committed sins, God will forgive him.
+
+\s5
+\v 16 So confess your sins to one another and pray for each other so that you may be healed. The prayer of a righteous person is very strong in its working.
+\v 17 Elijah was a man just like us. He prayed earnestly that it would not rain, and it did not rain in the land for three years and six months.
+\v 18 Then Elijah prayed again. The heavens gave rain, and the earth produced its fruit.
+
+\s5
+\p
+\v 19 My brothers, if anyone among you strays from the truth, and someone brings him back,
+\v 20 that person should know that whoever turns a sinner from the error of his way will save him from death and will cover over a great number of sins.
+

--- a/fetcher-web/src/test/resources/titus_test/README.md
+++ b/fetcher-web/src/test/resources/titus_test/README.md
@@ -1,0 +1,13 @@
+# Unlocked Literal Bible - English
+a Bible intended to be freely available for people to translate into any language
+## Overview
+The Unlocked Literal Bible (ULB) is an open-licensed version of the Bible derived from The American Standard Version, and updated using the most reliable Hebrew, Aramaic, and Greek copies of the Biblical texts available. It is intended to accurately reflect the meanings of those texts and to be used as a source text for Bible translators to translate the Bible into their own language.
+This repository contains the USFM source files for the Unlocked Literal Bible.
+## Viewing
+To read or print the formatted ULB, see the English Unlocked Literal Bible on [Bible in Every Language] (https://bibleineverylanguage.org/index.php/translations/).
+To view the repository of the Unlocked *Dynamic* Bible, go to [WycliffeAssociates/en_udb] (https://git.door43.org/WycliffeAssociates/en_udb).
+## Contributors
+If you are a contributor to this ULB project, please add your name to the contributor
+field in the [manifest.yaml](https://git.door43.org/WycliffeAssociates/en_ulb/src/branch/master/manifest.yaml) file.
+If you will be editing this ULB, please see [Introduction to the ULB] (https://git.door43.org/WycliffeAssociates/en_ulb/src/branch/master/00-About_the_ULB/ULB-1-Intro.md) and [Decisions Concerning the ULB] (https://git.door43.org/WycliffeAssociates/en_ulb/src/branch/master/00-About_the_ULB/ULB-2-Decisions.md).
+

--- a/fetcher-web/src/test/resources/titus_test/manifest.yaml
+++ b/fetcher-web/src/test/resources/titus_test/manifest.yaml
@@ -1,0 +1,41 @@
+---
+dublin_core:
+  conformsto: 'rc0.2'
+  contributor: []
+  creator: 'Door43 World Missions Community'
+  description: "An open-licensed update of the ASV, intended to provide a 'form-centric' understanding of the Bible. It increases the translator's understanding of the lexical and grammatical composition of the underlying text by adhering closely to the word order and structure of the originals."
+  format: 'text/usfm'
+  identifier: 'ulb'
+  issued: '2017-11-29'
+  language:
+    direction: 'ltr'
+    identifier: 'en-x-demo1'
+    title: 'English'
+  modified: '2017-11-29'
+  publisher: 'unfoldingWord'
+  relation:
+    - 'en/tw'
+    - 'en/tq'
+    - 'en/tn'
+  rights: 'CC BY-SA 4.0'
+  source:
+    -
+      identifier: 'asv'
+      language: 'en'
+      version: '1901'
+  subject: 'Bible'
+  title: 'Unlocked Literal Bible'
+  type: 'bundle'
+  version: '12'
+checking:
+  checking_entity:
+    - 'unfoldingWord'
+  checking_level: '3'
+projects:
+  -
+    title: 'Titus'
+    versification: 'ufw'
+    identifier: 'tit'
+    sort: 60
+    path: './60-JAS.usfm'
+    categories: [ 'bible-nt'  ]

--- a/fetcher-web/src/test/resources/titus_test/media.yaml
+++ b/fetcher-web/src/test/resources/titus_test/media.yaml
@@ -1,0 +1,13 @@
+---
+resource:
+  version: "{latest}"
+  media: []
+projects:
+- identifier: "tit"
+  version: "{latest}"
+  media:
+  - identifier: "mp3"
+    version: "{latest}"
+    url: ""
+    quality: []
+    chapter_url: "media/tit/chapters/en_nt_ulb_tit_c0{chapter}.mp3"


### PR DESCRIPTION
Update to use better way, comparing to [#76](https://github.com/Bible-Translation-Tools/Fetcher/pull/76)

- This improves performance by taking less time to produce an Orature file: 

```
copy rc dir to output > send to downloader > zip up
instead of 
zip to output> send to downloader
```

> working with a folder is better than with a zip

- Updated unit test + test resource

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/127)
<!-- Reviewable:end -->
