### PR TITLE
Missing chapters in Psalms

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ChapterCatalogImpl.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ChapterCatalogImpl.kt
@@ -21,6 +21,9 @@ class ChapterCatalogImpl : ChapterCatalog {
         val id: String,
         val lastvs: String
     ) {
+        // e.g. "id": "04-06", then chapter number is 04
+        val chapterNumber: Int = id.split('-').first().toInt()
+
         fun getChapter(): Int = id.split("-")[0].toInt()
     }
 
@@ -58,7 +61,7 @@ class ChapterCatalogImpl : ChapterCatalog {
     }
 
     private fun getLastChunk(chunkList: MutableList<Chunk>): Chunk {
-        chunkList.sortBy { it.id }
+        chunkList.sortBy { it.chapterNumber }
         return chunkList.last()
     }
 }


### PR DESCRIPTION
Sort by id which is a string would not be appropriate and it caused the catalog to have only 99 chapters
https://api.unfoldingword.org/ts/txt/2/psa/en/ulb/chunks.json

Issue: [en - psalms](https://audio.bibleineverylanguage.org/gl/en/mp3/psa)
![image](https://user-images.githubusercontent.com/34975907/113299065-793caa00-92ca-11eb-8479-d4f4982600a6.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/128)
<!-- Reviewable:end -->
