### PR TITLE
Remove JCenter repository

### DIFF
--- a/fetcher-web/build.gradle
+++ b/fetcher-web/build.gradle
@@ -29,6 +29,7 @@ sourceCompatibility = 11
 repositories {
     mavenCentral()
     maven { url "https://nexus-registry.walink.org/repository/maven-public/" }
+    maven { url "https://maven.pkg.jetbrains.space/public/p/kotlinx-html/maven" } // detekt report
     flatDir {
         dirs 'libs'
     }
@@ -56,6 +57,7 @@ dependencies {
     implementation "io.insert-koin:koin-ktor:$koin_ver"
 
     detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detekt_ver"
+    implementation "org.jetbrains.kotlinx:kotlinx-html-jvm:$kotlinx_html_ver" // detekt report
 }
 
 compileKotlin {

--- a/fetcher-web/build.gradle
+++ b/fetcher-web/build.gradle
@@ -29,7 +29,6 @@ sourceCompatibility = 11
 repositories {
     mavenCentral()
     maven { url "https://nexus-registry.walink.org/repository/maven-public/" }
-    jcenter()
     flatDir {
         dirs 'libs'
     }

--- a/fetcher-web/dependencies.gradle
+++ b/fetcher-web/dependencies.gradle
@@ -1,6 +1,7 @@
 ext {
     // Plugins
-    detekt_ver = '1.10.0-RC1'
+    detekt_ver = '1.16.0'
+    kotlinx_html_ver='0.7.2' // detekt report
     ktlint_ver = '9.2.1'
     shadowjar_ver = '5.2.0'
 

--- a/fetcher-web/dependencies.gradle
+++ b/fetcher-web/dependencies.gradle
@@ -15,7 +15,7 @@ ext {
     mockito_core_ver = '3.3.3'
     ktor_client_ver = '1.5.2'
     retrofit_ver='2.9.0'
-    resource_container_ver='0.7.0'
+    resource_container_ver='0.8.0'
     rc_media_downloader_ver='1.1.3'
     fuzzy_wuzzy_ver='1.3.1'
     koin_ver='3.0.1-beta-2'

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
@@ -30,7 +30,7 @@ import org.koin.dsl.module
 import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 
 val appDependencyModule = module(createdAtStart = true) {
-    val envConfig: EnvironmentConfig = when(System.getenv("ENVIRONMENT").toUpperCase()) {
+    val envConfig: EnvironmentConfig = when (System.getenv("ENVIRONMENT").toUpperCase()) {
         "PRODUCTION" -> EnvironmentConfig()
         "DEVELOPMENT" -> DevEnvironmentConfig()
         else -> throw ExceptionInInitializerError("Environment type is not defined or invalid.")

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
@@ -30,10 +30,10 @@ import org.koin.dsl.module
 import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 
 val appDependencyModule = module(createdAtStart = true) {
-    val envConfig: EnvironmentConfig = when(System.getenv("ENVIRONMENT")) {
+    val envConfig: EnvironmentConfig = when(System.getenv("ENVIRONMENT").toUpperCase()) {
         "PRODUCTION" -> EnvironmentConfig()
         "DEVELOPMENT" -> DevEnvironmentConfig()
-        else -> throw ExceptionInInitializerError("Environment type is not defined.")
+        else -> throw ExceptionInInitializerError("Environment type is not defined or invalid.")
     }
     single {
         envConfig


### PR DESCRIPTION
JCenter will sunset on May 1st, 2021

https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

![Capture](https://user-images.githubusercontent.com/34975907/114558128-5ac69f00-9c38-11eb-8d3f-547bbbe19411.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/133)
<!-- Reviewable:end -->
