### PR TITLE
Remove @Synchronized for accessing cache

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/AvailabilityCacheAccessor.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/AvailabilityCacheAccessor.kt
@@ -13,15 +13,12 @@ class AvailabilityCacheAccessor(
         cache = cacheBuilder.build()
     }
 
-    @Synchronized
     override fun update() {
         cache = cacheBuilder.build()
     }
 
-    @Synchronized
     override fun isLanguageAvailable(code: String) = cache.languages.any { it.code == code && it.availability }
 
-    @Synchronized
     override fun isProductAvailable(productSlug: String, languageCode: String): Boolean {
         return cache.languages.find {
             it.code == languageCode && it.availability
@@ -30,7 +27,6 @@ class AvailabilityCacheAccessor(
         } ?: false
     }
 
-    @Synchronized
     override fun isBookAvailable(
         bookSlug: String,
         languageCode: String,
@@ -47,7 +43,6 @@ class AvailabilityCacheAccessor(
         }
     }
 
-    @Synchronized
     override fun getChapterUrl(
         number: Int,
         bookSlug: String,
@@ -67,7 +62,6 @@ class AvailabilityCacheAccessor(
         }?.url
     }
 
-    @Synchronized
     override fun getBookUrl(
         bookSlug: String,
         languageCode: String,

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/AvailabilityCacheAccessor.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/AvailabilityCacheAccessor.kt
@@ -13,6 +13,7 @@ class AvailabilityCacheAccessor(
         cache = cacheBuilder.build()
     }
 
+    @Synchronized
     override fun update() {
         cache = cacheBuilder.build()
     }


### PR DESCRIPTION
Removed the @Synchronized annotation on cache accessor methods so that it doesn't block the client requests during cache update.
https://docs.oracle.com/javase/tutorial/essential/concurrency/syncmeth.html

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/137)
<!-- Reviewable:end -->
