### PR TITLE
Filter non-hidden files in audio directory

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/config/DevEnvironmentConfig.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/config/DevEnvironmentConfig.kt
@@ -3,6 +3,4 @@ package org.bibletranslationtools.fetcher.config
 /**
  * For Development only
  */
-class DevEnvironmentConfig : EnvironmentConfig() {
-    override val CDN_BASE_URL: String = "https://audio-content.bibleineverylanguage.org/content"
-}
+class DevEnvironmentConfig : EnvironmentConfig()

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
@@ -94,7 +94,9 @@ class StorageAccessImpl(private val directoryProvider: DirectoryProvider) : Stor
         )
 
         return try {
-            bookContentDir.listFiles(File::isFile)?.single()
+            bookContentDir.listFiles(
+                FileFilter { it.isFile && !it.isHidden }
+            )?.single()
         } catch (e: NoSuchElementException) {
             // no content
             null
@@ -126,9 +128,7 @@ class StorageAccessImpl(private val directoryProvider: DirectoryProvider) : Stor
 
         return try {
             chapterContentDir.listFiles(
-                FileFilter {
-                    it.isFile && !it.isHidden
-                }
+                FileFilter { it.isFile && !it.isHidden }
             )?.single()
         } catch (e: NoSuchElementException) {
             // no content

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
@@ -125,7 +125,11 @@ class StorageAccessImpl(private val directoryProvider: DirectoryProvider) : Stor
         )
 
         return try {
-            chapterContentDir.listFiles(File::isFile)?.single()
+            chapterContentDir.listFiles(
+                FileFilter {
+                    it.isFile && !it.isHidden
+                }
+            )?.single()
         } catch (e: NoSuchElementException) {
             // no content
             null


### PR DESCRIPTION
The pipeline may write a .hash file next to the audio for versioning and update. Hidden files should not be counted as a file in File Filter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/152)
<!-- Reviewable:end -->
