### PR TITLE
Rebuild RC media url on request

### DIFF
--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/di/DIModule.kt
@@ -64,7 +64,6 @@ val appDependencyModule = module(createdAtStart = true) {
             productCatalog = get(),
             chapterCatalog = get(),
             bookRepository = get(),
-            rcRepo = get(),
             storageAccess = get()
         )
     }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
@@ -97,6 +97,7 @@ class ContentAvailabilityCacheBuilder(
         language: Language,
         book: Book
     ): List<ChapterCache> {
+        // if there content in mp3, then Orature content should be available
         val product = productCatalog.getProduct(ProductFileExtension.MP3.fileType)!!
         val chapters = audioChapters(language, product, book)
         chapters.forEach {

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/ContentAvailabilityCacheBuilder.kt
@@ -1,6 +1,5 @@
 package org.bibletranslationtools.fetcher.impl.repository
 
-import java.io.File
 import java.util.stream.Collectors
 import org.bibletranslationtools.fetcher.config.EnvironmentConfig
 import org.bibletranslationtools.fetcher.data.Book
@@ -10,19 +9,16 @@ import org.bibletranslationtools.fetcher.repository.BookRepository
 import org.bibletranslationtools.fetcher.repository.ChapterCatalog
 import org.bibletranslationtools.fetcher.repository.LanguageCatalog
 import org.bibletranslationtools.fetcher.repository.ProductCatalog
-import org.bibletranslationtools.fetcher.repository.ResourceContainerRepository
 import org.bibletranslationtools.fetcher.repository.StorageAccess
 import org.bibletranslationtools.fetcher.usecase.FetchBookViewData
 import org.bibletranslationtools.fetcher.usecase.FetchChapterViewData
 import org.bibletranslationtools.fetcher.usecase.ProductFileExtension
-import org.bibletranslationtools.fetcher.usecase.RequestResourceContainer
 import org.bibletranslationtools.fetcher.usecase.cache.AvailabilityCache
 import org.bibletranslationtools.fetcher.usecase.cache.BookCache
 import org.bibletranslationtools.fetcher.usecase.cache.ChapterCache
 import org.bibletranslationtools.fetcher.usecase.cache.LanguageCache
 import org.bibletranslationtools.fetcher.usecase.cache.ProductCache
 import org.slf4j.LoggerFactory
-import org.wycliffeassociates.resourcecontainer.ResourceContainer
 
 class ContentAvailabilityCacheBuilder(
     private val envConfig: EnvironmentConfig,

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/impl/repository/StorageAccessImpl.kt
@@ -23,18 +23,35 @@ class StorageAccessImpl(private val directoryProvider: DirectoryProvider) : Stor
             bookSlug: String = "",
             chapter: String = ""
         ): File {
+            return getPathPrefixDir(
+                directoryProvider.getContentRoot(),
+                languageCode,
+                resourceId,
+                fileExtension,
+                bookSlug,
+                chapter
+            )
+        }
+
+        fun getPathPrefixDir(
+            root: File,
+            languageCode: String,
+            resourceId: String,
+            fileExtension: String,
+            bookSlug: String = "",
+            chapter: String = ""
+        ): File {
             val trimmedChapter = chapter.trimStart('0')
-            val sourceContentRootDir = directoryProvider.getContentRoot()
 
             return when {
                 bookSlug.isNotEmpty() && trimmedChapter.isNotEmpty() ->
-                    sourceContentRootDir.resolve(
+                    root.resolve(
                         "$languageCode/$resourceId/$bookSlug/$trimmedChapter/CONTENTS/$fileExtension"
                     )
-                bookSlug.isNotEmpty() -> sourceContentRootDir.resolve(
+                bookSlug.isNotEmpty() -> root.resolve(
                     "$languageCode/$resourceId/$bookSlug/CONTENTS/$fileExtension"
                 )
-                else -> sourceContentRootDir.resolve(
+                else -> root.resolve(
                     "$languageCode/$resourceId/CONTENTS/$fileExtension"
                 )
             }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/io/LocalFileTransferClient.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/io/LocalFileTransferClient.kt
@@ -21,7 +21,7 @@ class LocalFileTransferClient(
      * into a local path on the system, then copies it to outputDir
      */
     override fun downloadFromUrl(url: String, outputDir: File): File? {
-        val relativePath = File(url).relativeTo(File(envVars.CDN_BASE_URL))
+        val relativePath = File(url).relativeTo(File(envVars.CDN_BASE_RC_URL))
 
         // map to local path
         val sourceFile = File(envVars.CONTENT_ROOT_DIR).resolve(relativePath)

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
@@ -79,26 +79,6 @@ class FetchChapterViewData(
         return chapterList
     }
 
-    fun chapterFromDirectory(chapterNumber: Int): ChapterViewData {
-        var url: String? = null
-
-        for (priority in priorityList) {
-            val fileAccessRequest = when (productExtension) {
-                ProductFileExtension.BTTR -> getBTTRFileAccessRequest(chapterNumber, priority)
-                ProductFileExtension.MP3 -> getMp3FileAccessRequest(chapterNumber, priority)
-                else -> return ChapterViewData(chapterNumber, null)
-            }
-
-            val chapterFile = storage.getChapterFile(fileAccessRequest)
-            if (chapterFile != null) {
-                url = formatChapterDownloadUrl(chapterFile)
-                break
-            }
-        }
-
-        return ChapterViewData(chapterNumber, url)
-    }
-
     private fun getBTTRFileAccessRequest(
         chapterNumber: Int,
         priorityItem: PriorityItem

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
@@ -24,13 +24,7 @@ class FetchChapterViewData(
     private val productExtension = ProductFileExtension.getType(product.slug)!!
     private val baseUrl = environmentConfig.CDN_BASE_URL
 
-    private data class PriorityItem(val fileExtension: String, val mediaQuality: String)
-
-    private val priorityList = listOf(
-        PriorityItem("mp3", "hi"),
-        PriorityItem("mp3", "low"),
-        PriorityItem("wav", "")
-    )
+    data class PriorityItem(val fileExtension: String, val mediaQuality: String)
 
     private val chapters: List<Chapter> = try {
         chapterCatalog.getAll(
@@ -85,6 +79,26 @@ class FetchChapterViewData(
         return chapterList
     }
 
+    fun chapterFromDirectory(chapterNumber: Int): ChapterViewData {
+        var url: String? = null
+
+        for (priority in priorityList) {
+            val fileAccessRequest = when (productExtension) {
+                ProductFileExtension.BTTR -> getBTTRFileAccessRequest(chapterNumber, priority)
+                ProductFileExtension.MP3 -> getMp3FileAccessRequest(chapterNumber, priority)
+                else -> return ChapterViewData(chapterNumber, null)
+            }
+
+            val chapterFile = storage.getChapterFile(fileAccessRequest)
+            if (chapterFile != null) {
+                url = formatChapterDownloadUrl(chapterFile)
+                break
+            }
+        }
+
+        return ChapterViewData(chapterNumber, url)
+    }
+
     private fun getBTTRFileAccessRequest(
         chapterNumber: Int,
         priorityItem: PriorityItem
@@ -100,7 +114,7 @@ class FetchChapterViewData(
         )
     }
 
-    private fun getMp3FileAccessRequest(
+    fun getMp3FileAccessRequest(
         chapterNumber: Int,
         priorityItem: PriorityItem
     ): FileAccessRequest {
@@ -117,5 +131,13 @@ class FetchChapterViewData(
     private fun formatChapterDownloadUrl(chapterFile: File): String {
         val relativeChapterPath = chapterFile.relativeTo(storage.getContentRoot()).invariantSeparatorsPath
         return "$baseUrl/$relativeChapterPath"
+    }
+
+    companion object {
+        val priorityList = listOf(
+            PriorityItem("mp3", "hi"),
+            PriorityItem("mp3", "low"),
+            PriorityItem("wav", "")
+        )
     }
 }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/FetchChapterViewData.kt
@@ -24,7 +24,13 @@ class FetchChapterViewData(
     private val productExtension = ProductFileExtension.getType(product.slug)!!
     private val baseUrl = environmentConfig.CDN_BASE_URL
 
-    data class PriorityItem(val fileExtension: String, val mediaQuality: String)
+    private data class PriorityItem(val fileExtension: String, val mediaQuality: String)
+
+    private val priorityList = listOf(
+        PriorityItem("mp3", "hi"),
+        PriorityItem("mp3", "low"),
+        PriorityItem("wav", "")
+    )
 
     private val chapters: List<Chapter> = try {
         chapterCatalog.getAll(
@@ -94,7 +100,7 @@ class FetchChapterViewData(
         )
     }
 
-    fun getMp3FileAccessRequest(
+    private fun getMp3FileAccessRequest(
         chapterNumber: Int,
         priorityItem: PriorityItem
     ): FileAccessRequest {
@@ -111,13 +117,5 @@ class FetchChapterViewData(
     private fun formatChapterDownloadUrl(chapterFile: File): String {
         val relativeChapterPath = chapterFile.relativeTo(storage.getContentRoot()).invariantSeparatorsPath
         return "$baseUrl/$relativeChapterPath"
-    }
-
-    companion object {
-        val priorityList = listOf(
-            PriorityItem("mp3", "hi"),
-            PriorityItem("mp3", "low"),
-            PriorityItem("wav", "")
-        )
     }
 }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
@@ -63,7 +63,7 @@ class RequestResourceContainer(
         val rcFile = storageAccess.allocateRCFileLocation(rcName)
         templateRC.copyRecursively(rcFile)
 
-        ResourceContainer.load(rcFile).use { rc->
+        ResourceContainer.load(rcFile).use { rc ->
             val mediaProject = rc.media?.projects?.firstOrNull {
                 it.identifier == deliverable.book.slug
             }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
@@ -5,6 +5,7 @@ import org.bibletranslationtools.fetcher.config.EnvironmentConfig
 import org.bibletranslationtools.fetcher.data.Deliverable
 import org.bibletranslationtools.fetcher.data.RCDeliverable
 import org.bibletranslationtools.fetcher.impl.repository.RCUtils
+import org.bibletranslationtools.fetcher.impl.repository.StorageAccessImpl
 import org.bibletranslationtools.fetcher.repository.ResourceContainerRepository
 import org.bibletranslationtools.fetcher.repository.StorageAccess
 import org.wycliffeassociates.rcmediadownloader.RCMediaDownloader
@@ -12,6 +13,8 @@ import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
 import org.wycliffeassociates.rcmediadownloader.data.MediaType
 import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
 import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
+import org.wycliffeassociates.resourcecontainer.ResourceContainer
+import org.wycliffeassociates.resourcecontainer.entity.Media
 
 class RequestResourceContainer(
     envConfig: EnvironmentConfig,
@@ -24,16 +27,7 @@ class RequestResourceContainer(
     fun getResourceContainer(
         deliverable: Deliverable
     ): RCDeliverable? {
-        val templateRC = rcRepository.getRC(
-            deliverable.language.code,
-            deliverable.resourceId
-        ) ?: return null
-
-        // allocate rc to delivery location
-        val rcName = RCUtils.createRCFileName(deliverable, "")
-        val rc = storageAccess.allocateRCFileLocation(rcName)
-        templateRC.copyRecursively(rc)
-
+        val rc = prepareRC(deliverable) ?: return null
         downloadMediaInRC(rc, deliverable)
 
         val hasContent = RCUtils.verifyChapterExists(
@@ -53,6 +47,77 @@ class RequestResourceContainer(
             zipFile.parentFile.deleteRecursively()
             null
         }
+    }
+
+    private fun prepareRC(deliverable: Deliverable): File? {
+        val templateRC = rcRepository.getRC(
+            deliverable.language.code,
+            deliverable.resourceId
+        )
+        if (templateRC == null || !templateRC.exists()) {
+            return null
+        }
+
+        // allocate rc to delivery location
+        val rcName = RCUtils.createRCFileName(deliverable, "")
+        val rcFile = storageAccess.allocateRCFileLocation(rcName)
+        templateRC.copyRecursively(rcFile)
+
+        ResourceContainer.load(rcFile).use { rc->
+            val mediaProject = rc.media?.projects?.firstOrNull {
+                it.identifier == deliverable.book.slug
+            }
+
+            val mediaList = mutableListOf<Media>()
+            for (mediaType in mediaTypes) {
+                val mediaIdentifier = mediaType.name.toLowerCase()
+                val chapterUrl = buildChapterMediaPath(
+                    deliverable,
+                    mediaIdentifier,
+                    mediaQualityMap[mediaIdentifier]!!)
+                val newMediaEntry = Media(
+                    mediaIdentifier,
+                    "",
+                    "",
+                    listOf(),
+                    chapterUrl.invariantSeparatorsPath
+                )
+                mediaList.add(newMediaEntry)
+            }
+            mediaProject?.media = mediaList
+            rc.writeMedia()
+        }
+
+        return rcFile
+    }
+
+    private fun buildChapterMediaPath(
+        deliverable: Deliverable,
+        extension: String,
+        quality: String
+    ): File {
+        val root = File(baseRCUrl)
+        val prefixPath = StorageAccessImpl.getPathPrefixDir(
+            root,
+            deliverable.language.code,
+            deliverable.resourceId,
+            extension,
+            deliverable.book.slug,
+            "{chapter}"
+        )
+
+        val chapterPath = StorageAccessImpl.getContentDir(
+            prefixPath,
+            extension,
+            extension,
+            quality,
+            "chapter"
+        )
+
+        val fileName = "${deliverable.language.code}_${deliverable.resourceId}" +
+                "_${deliverable.book.slug}_c{chapter}.$extension"
+
+        return chapterPath.resolve(fileName)
     }
 
     private fun downloadMediaInRC(rcFile: File, deliverable: Deliverable): File {
@@ -78,5 +143,10 @@ class RequestResourceContainer(
 
     companion object {
         val mediaTypes = listOf(MediaType.MP3)
+
+        private val mediaQualityMap = mapOf(
+            "mp3" to "hi",
+            "wav" to ""
+        )
     }
 }

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
@@ -74,7 +74,8 @@ class RequestResourceContainer(
                 val chapterUrl = buildChapterMediaPath(
                     deliverable,
                     mediaIdentifier,
-                    mediaQualityMap[mediaIdentifier]!!)
+                    mediaQualityMap[mediaIdentifier]!!
+                )
                 val newMediaEntry = Media(
                     mediaIdentifier,
                     "",

--- a/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
+++ b/fetcher-web/src/main/kotlin/org/bibletranslationtools/fetcher/usecase/RequestResourceContainer.kt
@@ -62,7 +62,12 @@ class RequestResourceContainer(
         val rcName = RCUtils.createRCFileName(deliverable, "")
         val rcFile = storageAccess.allocateRCFileLocation(rcName)
         templateRC.copyRecursively(rcFile)
+        overwriteRCMediaManifest(rcFile, deliverable)
 
+        return rcFile
+    }
+
+    private fun overwriteRCMediaManifest(rcFile: File, deliverable: Deliverable) {
         ResourceContainer.load(rcFile).use { rc ->
             val mediaProject = rc.media?.projects?.firstOrNull {
                 it.identifier == deliverable.book.slug
@@ -71,7 +76,7 @@ class RequestResourceContainer(
             val mediaList = mutableListOf<Media>()
             for (mediaType in mediaTypes) {
                 val mediaIdentifier = mediaType.name.toLowerCase()
-                val chapterUrl = buildChapterMediaPath(
+                val chapterUrl = buildChapterMediaUrl(
                     deliverable,
                     mediaIdentifier,
                     mediaQualityMap[mediaIdentifier]!!
@@ -88,11 +93,9 @@ class RequestResourceContainer(
             mediaProject?.media = mediaList
             rc.writeMedia()
         }
-
-        return rcFile
     }
 
-    private fun buildChapterMediaPath(
+    private fun buildChapterMediaUrl(
         deliverable: Deliverable,
         extension: String,
         quality: String

--- a/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/ContentAvailabilityCacheTest.kt
+++ b/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/ContentAvailabilityCacheTest.kt
@@ -59,7 +59,7 @@ class ContentAvailabilityCacheTest {
         )
 
         withEnvironmentVariable("CONTENT_ROOT", tempDir.path)
-            .and("CDN_BASE_URL", "https://audio-content.bibleineverylanguage.org/content")
+            .and("CDN_BASE_URL", "unused")
             .and("CDN_BASE_RC_URL", "unused")
             .and("CACHE_REFRESH_MINUTES", "unused")
             .and("ORATURE_REPO_DIR", "unused")

--- a/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/LocalFileTransferClientTest.kt
+++ b/fetcher-web/src/test/kotlin/org/bibletranslationtools/fetcher/LocalFileTransferClientTest.kt
@@ -25,8 +25,8 @@ class LocalFileTransferClientTest {
         srcFile.writeText("test content")
 
         withEnvironmentVariable("CONTENT_ROOT", mockContentDir.path)
-            .and("CDN_BASE_URL", mockCDN)
-            .and("CDN_BASE_RC_URL", "unused")
+            .and("CDN_BASE_URL", "unused")
+            .and("CDN_BASE_RC_URL", mockCDN)
             .and("CACHE_REFRESH_MINUTES", "unused")
             .and("ORATURE_REPO_DIR", "unused")
             .and("RC_TEMP_DIR", "unused")


### PR DESCRIPTION
Removes dependency on media.yaml coming from WACS; Fetches from local storage to overwrite media url entries for requested RC.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/fetcher/154)
<!-- Reviewable:end -->
